### PR TITLE
Add test coverage for when monitoring tests all pass

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synthetic_monitor (0.3.0)
+    synthetic_monitor (0.4.0)
       rest-client
       rspec (= 3.2.0)
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
 require 'rake/testtask'
 
 Rake::TestTask.new do |task|
-  task.libs << %w(test lib)
-  task.pattern = 'functional_test/functional_test.rb'
+  task.libs << "functional_test"
+  task.pattern = 'functional_test/**/*_test.rb'
 end
 
 task :default => :test

--- a/functional_test/functional_test.rb
+++ b/functional_test/functional_test.rb
@@ -31,6 +31,18 @@ class FunctionalTest < Minitest::Test
     retryable { JSON.parse(@mirage.requests(1).body) }
   end
 
+  def test_run_all_specs
+    @monitor_thread = Thread.new { SyntheticMonitor.new.monitor ENV['SLACK_WEBHOOK'] }
+    assert_notification_sent_to_slack
+    assert_no_success_notification_sent
+  end
+
+  def test_run_failure_spec
+    @monitor_thread = Thread.new { SyntheticMonitor.new.monitor 'spec/failure_spec.rb', ENV['SLACK_WEBHOOK'] }
+    assert_notification_sent_to_slack
+    assert_no_success_notification_sent
+  end
+
   def test_run_success_spec
     @monitor_thread = Thread.new {
       monitor = SyntheticMonitor.new(success_notifications_url: success_notifications_post_url)

--- a/functional_test/functional_test.rb
+++ b/functional_test/functional_test.rb
@@ -9,6 +9,7 @@ class FunctionalTest < Minitest::Test
 
   def setup
     ENV.store 'SLACK_WEBHOOK', 'http://localhost:7001/responses/slack'
+    delete_all_success_notifications
     Mirage.start
     @mirage = Mirage::Client.new
     @mirage.put('slack', 'Notification received on Slack') { http_method 'POST' }
@@ -42,6 +43,18 @@ class FunctionalTest < Minitest::Test
     retryable { JSON.parse(@mirage.requests(1).body) }
   end
 
+  def success_notifications
+    runscope_messages = JSON.parse( RestClient.get "https://api.runscope.com/buckets/32dq2c18qk24/stream", {:Authorization => 'Bearer 05d16442-31df-4f23-947d-9a5eec4f0525'} )
+    assert_equal "success", runscope_messages["meta"]["status"]
+    runscope_messages["data"]
+  end
+
+  def delete_all_success_notifications
+    success_notifications.each do | message |
+      RestClient.delete "https://api.runscope.com/buckets/32dq2c18qk24/messages/#{message['uuid']}", {:Authorization => 'Bearer 05d16442-31df-4f23-947d-9a5eec4f0525'}
+    end
+  end
+
   def test_run_all_specs
     @monitor_thread = Thread.new { SyntheticMonitor.new.monitor ENV['SLACK_WEBHOOK'] }
     assert_notification_sent_to_slack
@@ -53,14 +66,23 @@ class FunctionalTest < Minitest::Test
   end
 
   def test_run_success_spec
-    @monitor_thread = Thread.new { SyntheticMonitor.new.monitor 'spec/success_spec.rb', ENV['SLACK_WEBHOOK'] }
+    @monitor_thread = Thread.new {
+      monitor = SyntheticMonitor.new(success_notifications_url: 'https://32dq2c18qk24.runscope.net')
+      monitor.monitor 'spec/success_spec.rb', ENV['SLACK_WEBHOOK']
+    }
     assert_no_notification_sent_to_slack
+    assert_equal 1, success_notifications.size
+    success_notification = JSON.parse( RestClient.get "https://api.runscope.com/buckets/32dq2c18qk24/messages/#{success_notifications.first['uuid']}", {:Authorization => 'Bearer 05d16442-31df-4f23-947d-9a5eec4f0525'} )
+    body = JSON.parse success_notification["data"]["request"]["body"]
+    assert_equal("all monitoring tests passed", body["data"])
   end
+
 
   def teardown
     @monitor_thread.exit
     @mirage.clear
     Mirage.stop
+    delete_all_success_notifications
   end
 
 end

--- a/functional_test/functional_test.rb
+++ b/functional_test/functional_test.rb
@@ -17,8 +17,6 @@ class FunctionalTest < Minitest::Test
     @mirage = Mirage::Client.new
     @mirage.put('slack', 'Notification received on Slack') { http_method 'POST' }
     @expected_slack_notification_request_body = {"attachments"=> [{"fallback"=>"ALERT: 1 test failed", "color"=>"danger", "title"=>"ALERT: 1 test failed", "fields"=> [{"title"=>"failing test example example of a test which will fail, triggering a notification on Slack", "value"=>"\n\nexpected: 500\n     got: 200\n\n(compared using ==)\n\n# ./spec/failure_spec.rb:13\n==================================================="}]}]}
-    @runscope_bucket_key = "32dq2c18qk24"
-    @success_notifications_url = "https://#{@runscope_bucket_key}.runscope.net"
   end
 
   def assert_notification_sent_to_slack
@@ -35,7 +33,7 @@ class FunctionalTest < Minitest::Test
 
   def test_run_success_spec
     @monitor_thread = Thread.new {
-      monitor = SyntheticMonitor.new(success_notifications_url: @success_notifications_url)
+      monitor = SyntheticMonitor.new(success_notifications_url: success_notifications_post_url)
       monitor.monitor 'spec/success_spec.rb', ENV['SLACK_WEBHOOK']
     }
     assert_no_notification_sent_to_slack

--- a/functional_test/functional_test.rb
+++ b/functional_test/functional_test.rb
@@ -35,6 +35,17 @@ class FunctionalTest < Minitest::Test
     runscope_messages["data"]
   end
 
+  def assert_success_notification_sent
+    assert_equal 1, success_notifications.size
+    success_notification = JSON.parse( RestClient.get "https://api.runscope.com/buckets/32dq2c18qk24/messages/#{success_notifications.first['uuid']}", {:Authorization => 'Bearer 05d16442-31df-4f23-947d-9a5eec4f0525'} )
+    body = JSON.parse success_notification["data"]["request"]["body"]
+    assert_equal("all monitoring tests passed", body["data"])
+  end
+
+  def assert_no_success_notification_sent
+    assert_empty success_notifications
+  end
+
   def delete_all_success_notifications
     success_notifications.each do | message |
       RestClient.delete "https://api.runscope.com/buckets/32dq2c18qk24/messages/#{message['uuid']}", {:Authorization => 'Bearer 05d16442-31df-4f23-947d-9a5eec4f0525'}
@@ -44,11 +55,13 @@ class FunctionalTest < Minitest::Test
   def test_run_all_specs
     @monitor_thread = Thread.new { SyntheticMonitor.new.monitor ENV['SLACK_WEBHOOK'] }
     assert_notification_sent_to_slack
+    assert_no_success_notification_sent
   end
 
   def test_run_failure_spec
     @monitor_thread = Thread.new { SyntheticMonitor.new.monitor 'spec/failure_spec.rb', ENV['SLACK_WEBHOOK'] }
     assert_notification_sent_to_slack
+    assert_no_success_notification_sent
   end
 
   def test_run_success_spec
@@ -57,10 +70,6 @@ class FunctionalTest < Minitest::Test
       monitor.monitor 'spec/success_spec.rb', ENV['SLACK_WEBHOOK']
     }
     assert_no_notification_sent_to_slack
-    assert_equal 1, success_notifications.size
-    success_notification = JSON.parse( RestClient.get "https://api.runscope.com/buckets/32dq2c18qk24/messages/#{success_notifications.first['uuid']}", {:Authorization => 'Bearer 05d16442-31df-4f23-947d-9a5eec4f0525'} )
-    body = JSON.parse success_notification["data"]["request"]["body"]
-    assert_equal("all monitoring tests passed", body["data"])
   end
 
 

--- a/functional_test/functional_test.rb
+++ b/functional_test/functional_test.rb
@@ -12,24 +12,49 @@ class FunctionalTest < Minitest::Test
     Mirage.start
     @mirage = Mirage::Client.new
     @mirage.put('slack', 'Notification received on Slack') { http_method 'POST' }
-    @expected_slack_notification_request_body = {"attachments"=> [{"fallback"=>"ALERT: 1 test failed", "color"=>"danger", "title"=>"ALERT: 1 test failed", "fields"=> [{"title"=>"example example of a test which will fail, triggering a notification on Slack", "value"=>"\n\nexpected: 500\n     got: 200\n\n(compared using ==)\n\n# ./spec/example_spec.rb:19\n==================================================="}]}]}
+    @expected_slack_notification_request_body = {"attachments"=> [{"fallback"=>"ALERT: 1 test failed", "color"=>"danger", "title"=>"ALERT: 1 test failed", "fields"=> [{"title"=>"failing test example example of a test which will fail, triggering a notification on Slack", "value"=>"\n\nexpected: 500\n     got: 200\n\n(compared using ==)\n\n# ./spec/failure_spec.rb:13\n==================================================="}]}]}
   end
 
   def retryable &block
-    yield rescue retry
+    tries = 0
+    begin
+      yield
+    rescue
+      tries += 1
+      sleep 1
+      retry if tries < 10
+    end
   end
 
-  def assert_hashes_equal(expected, actual)
+  def assert_hashes_equal expected, actual
     assert_equal [], HashDiff.diff(expected, actual)
   end
 
   def assert_notification_sent_to_slack
-    assert_hashes_equal @expected_slack_notification_request_body, JSON.parse(@mirage.requests(1).body)
+    assert_hashes_equal @expected_slack_notification_request_body, request_body_sent_to_slack
   end
 
-  def test_one_test_fails_and_notifies_on_slack
+  def assert_no_notification_sent_to_slack
+    assert_nil request_body_sent_to_slack
+  end
+
+  def request_body_sent_to_slack
+    retryable { JSON.parse(@mirage.requests(1).body) }
+  end
+
+  def test_run_all_specs
     @monitor_thread = Thread.new { SyntheticMonitor.new.monitor ENV['SLACK_WEBHOOK'] }
-    retryable { assert_notification_sent_to_slack }
+    assert_notification_sent_to_slack
+  end
+
+  def test_run_failure_spec
+    @monitor_thread = Thread.new { SyntheticMonitor.new.monitor 'spec/failure_spec.rb', ENV['SLACK_WEBHOOK'] }
+    assert_notification_sent_to_slack
+  end
+
+  def test_run_success_spec
+    @monitor_thread = Thread.new { SyntheticMonitor.new.monitor 'spec/success_spec.rb', ENV['SLACK_WEBHOOK'] }
+    assert_no_notification_sent_to_slack
   end
 
   def teardown

--- a/functional_test/functional_test.rb
+++ b/functional_test/functional_test.rb
@@ -8,6 +8,8 @@ require 'minitest_helper'
 
 class FunctionalTest < Minitest::Test
 
+  include RunscopeHelper
+
   def setup
     ENV.store 'SLACK_WEBHOOK', 'http://localhost:7001/responses/slack'
     delete_all_success_notifications
@@ -15,6 +17,8 @@ class FunctionalTest < Minitest::Test
     @mirage = Mirage::Client.new
     @mirage.put('slack', 'Notification received on Slack') { http_method 'POST' }
     @expected_slack_notification_request_body = {"attachments"=> [{"fallback"=>"ALERT: 1 test failed", "color"=>"danger", "title"=>"ALERT: 1 test failed", "fields"=> [{"title"=>"failing test example example of a test which will fail, triggering a notification on Slack", "value"=>"\n\nexpected: 500\n     got: 200\n\n(compared using ==)\n\n# ./spec/failure_spec.rb:13\n==================================================="}]}]}
+    @runscope_bucket_key = "32dq2c18qk24"
+    @success_notifications_url = "https://#{@runscope_bucket_key}.runscope.net"
   end
 
   def assert_notification_sent_to_slack
@@ -29,49 +33,13 @@ class FunctionalTest < Minitest::Test
     retryable { JSON.parse(@mirage.requests(1).body) }
   end
 
-  def success_notifications
-    runscope_messages = JSON.parse( RestClient.get "https://api.runscope.com/buckets/32dq2c18qk24/stream", {:Authorization => 'Bearer 05d16442-31df-4f23-947d-9a5eec4f0525'} )
-    assert_equal "success", runscope_messages["meta"]["status"]
-    runscope_messages["data"]
-  end
-
-  def assert_success_notification_sent
-    assert_equal 1, success_notifications.size
-    success_notification = JSON.parse( RestClient.get "https://api.runscope.com/buckets/32dq2c18qk24/messages/#{success_notifications.first['uuid']}", {:Authorization => 'Bearer 05d16442-31df-4f23-947d-9a5eec4f0525'} )
-    body = JSON.parse success_notification["data"]["request"]["body"]
-    assert_equal("all monitoring tests passed", body["data"])
-  end
-
-  def assert_no_success_notification_sent
-    assert_empty success_notifications
-  end
-
-  def delete_all_success_notifications
-    success_notifications.each do | message |
-      RestClient.delete "https://api.runscope.com/buckets/32dq2c18qk24/messages/#{message['uuid']}", {:Authorization => 'Bearer 05d16442-31df-4f23-947d-9a5eec4f0525'}
-    end
-  end
-
-  def test_run_all_specs
-    @monitor_thread = Thread.new { SyntheticMonitor.new.monitor ENV['SLACK_WEBHOOK'] }
-    assert_notification_sent_to_slack
-    assert_no_success_notification_sent
-  end
-
-  def test_run_failure_spec
-    @monitor_thread = Thread.new { SyntheticMonitor.new.monitor 'spec/failure_spec.rb', ENV['SLACK_WEBHOOK'] }
-    assert_notification_sent_to_slack
-    assert_no_success_notification_sent
-  end
-
   def test_run_success_spec
     @monitor_thread = Thread.new {
-      monitor = SyntheticMonitor.new(success_notifications_url: 'https://32dq2c18qk24.runscope.net')
+      monitor = SyntheticMonitor.new(success_notifications_url: @success_notifications_url)
       monitor.monitor 'spec/success_spec.rb', ENV['SLACK_WEBHOOK']
     }
     assert_no_notification_sent_to_slack
   end
-
 
   def teardown
     @monitor_thread.exit

--- a/functional_test/functional_test.rb
+++ b/functional_test/functional_test.rb
@@ -4,6 +4,7 @@ require 'synthetic_monitor'
 require 'mirage/client'
 require 'json'
 require 'hashdiff'
+require 'minitest_helper'
 
 class FunctionalTest < Minitest::Test
 
@@ -14,21 +15,6 @@ class FunctionalTest < Minitest::Test
     @mirage = Mirage::Client.new
     @mirage.put('slack', 'Notification received on Slack') { http_method 'POST' }
     @expected_slack_notification_request_body = {"attachments"=> [{"fallback"=>"ALERT: 1 test failed", "color"=>"danger", "title"=>"ALERT: 1 test failed", "fields"=> [{"title"=>"failing test example example of a test which will fail, triggering a notification on Slack", "value"=>"\n\nexpected: 500\n     got: 200\n\n(compared using ==)\n\n# ./spec/failure_spec.rb:13\n==================================================="}]}]}
-  end
-
-  def retryable &block
-    tries = 0
-    begin
-      yield
-    rescue
-      tries += 1
-      sleep 1
-      retry if tries < 10
-    end
-  end
-
-  def assert_hashes_equal expected, actual
-    assert_equal [], HashDiff.diff(expected, actual)
   end
 
   def assert_notification_sent_to_slack

--- a/functional_test/minitest_helper.rb
+++ b/functional_test/minitest_helper.rb
@@ -1,3 +1,5 @@
+require 'rest-client'
+
 def retryable &block
   tries = 0
   begin
@@ -11,4 +13,49 @@ end
 
 def assert_hashes_equal expected, actual
   assert_equal [], HashDiff.diff(expected, actual)
+end
+
+
+module RunscopeHelper
+
+  BUCKET_KEY = "32dq2c18qk24"
+  AUTHORIZATION_HEADER = {:Authorization => 'Bearer 05d16442-31df-4f23-947d-9a5eec4f0525'}
+
+  def assert_success_notification_sent
+    assert_equal 1, success_notifications.size
+    success_notification = get_json message_url(success_notifications.first['uuid'])
+    body = JSON.parse success_notification["data"]["request"]["body"]
+    assert_equal("all monitoring tests passed", body["data"])
+  end
+
+  def assert_no_success_notification_sent
+    assert_empty success_notifications
+  end
+
+  def get_json url
+    JSON.parse( RestClient.get(url, AUTHORIZATION_HEADER) )
+  end
+
+  def bucket_url
+    "https://api.runscope.com/buckets/#{BUCKET_KEY}"
+  end
+
+  def message_url uuid
+    "#{bucket_url}/messages/#{uuid}"
+  end
+
+  def success_notifications
+    runscope_messages = get_json "#{bucket_url}/stream"
+    assert_equal "success", runscope_messages["meta"]["status"]
+    runscope_messages["data"]
+  end
+
+  def delete_message message
+    RestClient.delete message_url(message['uuid']), AUTHORIZATION_HEADER
+  end
+
+  def delete_all_success_notifications
+    success_notifications.each { | message | delete_message message }
+  end
+
 end

--- a/functional_test/minitest_helper.rb
+++ b/functional_test/minitest_helper.rb
@@ -50,6 +50,10 @@ module RunscopeHelper
     runscope_messages["data"]
   end
 
+  def success_notifications_post_url
+    "https://#{BUCKET_KEY}.runscope.net"
+  end
+
   def delete_message message
     RestClient.delete message_url(message['uuid']), AUTHORIZATION_HEADER
   end

--- a/functional_test/minitest_helper.rb
+++ b/functional_test/minitest_helper.rb
@@ -1,0 +1,14 @@
+def retryable &block
+  tries = 0
+  begin
+    yield
+  rescue
+    tries += 1
+    sleep 1
+    retry if tries < 10
+  end
+end
+
+def assert_hashes_equal expected, actual
+  assert_equal [], HashDiff.diff(expected, actual)
+end

--- a/spec/failure_spec.rb
+++ b/spec/failure_spec.rb
@@ -4,16 +4,10 @@ require 'capybara/poltergeist'
 require 'capybara/dsl'
 require 'spec_helper'
 
-feature "example" do
+feature "failing test example" do
 
   before(:all) do
     @session = Capybara::Session.new(:poltergeist)
-  end
-
-  scenario "example of a test which will pass, meaning no notification is sent to Slack" do
-    @session.visit 'https://www.example.com'
-    expect(@session).to have_content("This domain is established to be used for illustrative examples in documents.")
-    expect(@session.status_code).to eq(200)
   end
 
   scenario "example of a test which will fail, triggering a notification on Slack" do

--- a/spec/success_spec.rb
+++ b/spec/success_spec.rb
@@ -1,0 +1,23 @@
+require 'rspec'
+require 'capybara/rspec'
+require 'capybara/poltergeist'
+require 'capybara/dsl'
+require 'spec_helper'
+
+feature "successful test example" do
+
+  before(:all) do
+    @session = Capybara::Session.new(:poltergeist)
+  end
+
+  scenario "example of a test which will pass, meaning no notification is sent to Slack" do
+    @session.visit 'https://www.example.com'
+    expect(@session).to have_content("This domain is established to be used for illustrative examples in documents.")
+    expect(@session.status_code).to eq(200)
+  end
+
+  after(:all) do
+    @session.driver.quit
+  end
+
+end

--- a/synthetic_monitor.gemspec
+++ b/synthetic_monitor.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'synthetic_monitor'
-  spec.version     = '0.3.0'
+  spec.version     = '0.4.0'
   spec.date        = '2015-04-28'
   spec.summary     = "Simple synthetic monitoring - runs rspec specs every x minutes and alerts on Slack if any tests fail."
   spec.description = "Simple synthetic monitoring - runs rspec specs given to it every x minutes (defaults to 5 minutes but can be overridden) and alerts on a Slack channel or group of your choosing if any tests fail."


### PR DESCRIPTION
<a href="https://github.com/johnboyes"><img src="https://avatars.githubusercontent.com/u/154404?v=3" align="left" width="96" height="96" hspace="10"></img></a> **Issue by [johnboyes](https://github.com/johnboyes)**
_Saturday Aug 15, 2015 at 12:22 GMT_
_Originally opened as https://github.com/johnboyes/example-synthetic-monitor/issues/3_

----

 Could use a [runscope capture](https://www.runscope.com/docs/request-capture) or similar to verify this
