### PR TITLE
need to assert that a success notification is sent when all tests pass

### DIFF
--- a/functional_test/functional_test.rb
+++ b/functional_test/functional_test.rb
@@ -8,27 +8,13 @@ require 'minitest_helper'
 
 class FunctionalTest < Minitest::Test
 
-  include RunscopeHelper
-
   def setup
     ENV.store 'SLACK_WEBHOOK', 'http://localhost:7001/responses/slack'
-    delete_all_success_notifications
     Mirage.start
     @mirage = Mirage::Client.new
     @mirage.put('slack', 'Notification received on Slack') { http_method 'POST' }
+    @mirage.put('success', 'Success notification received') { http_method 'POST' }
     @expected_slack_notification_request_body = {"attachments"=> [{"fallback"=>"ALERT: 1 test failed", "color"=>"danger", "title"=>"ALERT: 1 test failed", "fields"=> [{"title"=>"failing test example example of a test which will fail, triggering a notification on Slack", "value"=>"\n\nexpected: 500\n     got: 200\n\n(compared using ==)\n\n# ./spec/failure_spec.rb:13\n==================================================="}]}]}
-  end
-
-  def assert_notification_sent_to_slack
-    assert_hashes_equal @expected_slack_notification_request_body, request_body_sent_to_slack
-  end
-
-  def assert_no_notification_sent_to_slack
-    assert_nil request_body_sent_to_slack
-  end
-
-  def request_body_sent_to_slack
-    retryable { JSON.parse(@mirage.requests(1).body) }
   end
 
   def test_run_all_specs
@@ -48,6 +34,7 @@ class FunctionalTest < Minitest::Test
       monitor = SyntheticMonitor.new(success_notifications_url: success_notifications_post_url)
       monitor.monitor 'spec/success_spec.rb', ENV['SLACK_WEBHOOK']
     }
+    assert_success_notification_sent
     assert_no_notification_sent_to_slack
   end
 
@@ -55,7 +42,5 @@ class FunctionalTest < Minitest::Test
     @monitor_thread.exit
     @mirage.clear
     Mirage.stop
-    delete_all_success_notifications
   end
-
 end


### PR DESCRIPTION
this will require removing Runscope completely (as Runscope no longer has a free plan) - can probably use Mirage instead.